### PR TITLE
get[Association] fails with belongsTo associations

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -216,7 +216,7 @@ utils.mixin(model, new (function () {
         // I belong to the other model; look for the item
         // whose id matches my foreign key for that model
         if (assnType == 'belongsTo') {
-          query.id = this[otherKeyName +  '(Id'];
+          query.id = this[otherKeyName +  'Id'];
         }
         // The other model belongs to me; look for any
         // items whose foreign keys match my id


### PR DESCRIPTION
There appears to be a typo on line 219 of lib/index.js. It caused
errors to throw with the postgres adapter during some experimentation
using model without geddy.

It has gone midnight here and I just wanted to see an experiment work before bed so I haven't written any test. I also fixed it inline with github as I was getting lazy. If you'd prefer me to write a test case, let me know.
