### PR TITLE
Make it possible to load an adapter within a model definition

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -751,9 +751,9 @@ model.ModelDefinitionBase = function (name) {
 
   this.name = name;
 
-  this.adapter = function (adapter) {
+  this.adapter = function (adapter, config) {
       var Adapter = require('./adapters/' + adapters.getAdapterInfo(adapter).filePath).Adapter;
-      model.adapters[name] = new Adapter();
+      model.adapters[name] = new Adapter(config);
   };
 
   this.property = function (name, datatype, o) {


### PR DESCRIPTION
This patch allows a user to define an adapter more easily, by putting a function in the model definition, i.e.

``` javascript
var model = require('model');

var User = function () {
  this.adapter('riak', { host: 'riakhost' });
}
User = model.register('User', User);
```

It wraps the getAdapterInfo function to find the path to the individual adapter, requires it, initializes it, and adds it to model.adapters. Additionally, it passes configuration options through to the adapter.
