### PR TITLE
fixed error in datatypes.serialize()

### DIFF
--- a/lib/datatypes.js
+++ b/lib/datatypes.js
@@ -203,7 +203,7 @@ datatypes = {
   , serialize: function (input, options) {
       var val
         , opts = options || {};
-      if (typeof val.toString == 'function') {
+      if (typeof input.toString == 'function') {
         val = input.toString();
       }
       else {


### PR DESCRIPTION
This one was preventing objects to serialize to strings and crashing the app when it tried to.
