### PR TITLE
Corrected sql generator for auto-increment int id column

### DIFF
--- a/lib/generators/sql.js
+++ b/lib/generators/sql.js
@@ -21,8 +21,10 @@ generator = new (function () {
   this.columnStatement = function (prop, options) {
     var sql = ''
       , opts = options || {};
-      sql = '  ' + utils.string.snakeize(prop.name) + ' ' +
-          datatypeMap[prop.datatype];
+      sql = '  ' + utils.string.snakeize(prop.name);
+      if (prop.datatype) {
+        sql += ' ' + datatypeMap[prop.datatype];
+      }
       if (opts.append) {
         sql += ' ' + opts.append;
       }


### PR DESCRIPTION
I got an error with postrgresql adapter and auto-increment id column of type int, saying "error near or et SERIAL" with no more output.
I figured out that the sql generator was trying to create a column id of type undefined, so I corrected it for the db:init task to work again
