### PR TITLE
Model.all returns multiple instances of the same object when using association eager loading

### DIFF
--- a/lib/adapters/sql/postgres.js
+++ b/lib/adapters/sql/postgres.js
@@ -41,7 +41,7 @@ utils.mixin(Adapter.prototype, new (function () {
             , rows
             , inst
             , models = {}
-            , mainId;
+            , mainIds = {};
 
           if (err) {
             callback(err, null);
@@ -89,14 +89,15 @@ utils.mixin(Adapter.prototype, new (function () {
                   , modelItem = models[p];
                 // Owner table-name
                 if (p == mainTable) {
-                  // This is a new id -- create an owner object
-                  if (params.id != mainId) {
+                  if (mainIds.hasOwnProperty(params.id)) {
+                    inst = mainIds[params.id];
+                  } else {
+                    // This is a new id -- create an owner object
                     inst = modelItem.ctor.create(params, {scenario: query.opts.scenario});
                     inst._saved = true;
                     res.push(inst);
+                    mainIds[params.id] = inst;
                   }
-                  // Update to check against next record
-                  mainId = params.id;
                 }
                 // Association table-name
                 else {


### PR DESCRIPTION
Association eager loading may create multiple instances of parent object because result set rows are not sorted by parent object id.
I actually got something like this:

``` coffeescript
geddy.model.DbConfig.all {}, {includes: ['db_connections']}, (err, dbConfigs) =>
  dbConfigs[0].id #=> "FOO123"
  dbConfigs[1].id #=> "BAR456"
  dbConfigs[2].id #=> "FOO123"   (duplicate object!)
```

And db_connections association objects were split in two halfs between this two copies of parent object.
