### PR TITLE
Fix for always empty rule.message.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -945,6 +945,7 @@ utils.mixin(model, new (function () {
     for (var p in validations) {
       validator = model.validators[p]
       rule = utils.mixin({},validations[p],{scenario: opts.scenario});
+      rule.message = validations[p].opts ? validations[p].opts.message : null;
 
       if (typeof validator != 'function') {
         throw new Error(p + ' is not a valid validator');


### PR DESCRIPTION
Hi,

I am using geddy and was trying to follow geddy documentation to get custom mode properties validation messages:

```
  this.validatesConfirmed('password', 'confirmPassword',
                          { message : 'My custom message here....'});
```

however it did not work.

Not sure if attached fix is best way to do it... but it works for me :)
