### PR TITLE
Update index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -534,6 +534,21 @@ utils.mixin(model, new (function () {
       return obj.all(query, opts, callback);
     };
 
+    obj.count = function() {
+      var args = Array.prototype.slice.call(arguments)
+        , callback = args.pop() || function () {};
+      adapt = model.getAdapterForModel(name);
+      if (!adapt) {
+        throw new Error('Adapter not found for ' + name);
+      }
+      else {
+        if (adapt.name == 'postgres') {
+          throw new Error('Only mongodb adapters support.');
+        }
+      }
+      return adapt.count(model[name],callback);
+    };
+
     // TODO: Deprecate
     obj.load = obj.first;
 


### PR DESCRIPTION
add count functions

```
obj.count = function() {
  var args = Array.prototype.slice.call(arguments)
    , callback = args.pop() || function () {};
  adapt = model.getAdapterForModel(name);
  if (!adapt) {
    throw new Error('Adapter not found for ' + name);
  }
  else {
    if (adapt.name == 'postgres') {
      throw new Error('Only mongodb adapters support.');
    }
  }
  return adapt.count(model[name],callback);
}
```
