### PR TITLE
Issue #101. Querying object's properties

### DIFF
--- a/lib/query/query.js
+++ b/lib/query/query.js
@@ -147,8 +147,9 @@ Query.prototype = new (function () {
 
         if (keyName.indexOf('.') > -1) {
           keyNameArr = keyName.split('.');
-          modelName = keyNameArr[1];
-          keyName = keyNameArr[0];
+          // transform modelName to ModelName
+          modelName = utils.string.getInflection(keyNameArr[0], 'constructor', 'singular');
+          keyName = keyNameArr[1];
         }
         else {
           modelName = this.model.modelName

--- a/test/fixtures/wooby.js
+++ b/test/fixtures/wooby.js
@@ -1,0 +1,9 @@
+var model = require('../../lib');
+
+var Wooby = function () {
+  this.property('foo', 'string');
+};
+
+Wooby = model.register('Wooby', Wooby);
+
+module.exports.Wooby = Wooby;

--- a/test/fixtures/zooby.js
+++ b/test/fixtures/zooby.js
@@ -10,10 +10,10 @@ var Zooby = function () {
   this.property('freen', 'date');
   this.property('zong', 'datetime');
   this.property('blarg', 'time');
+  this.property('wooby', 'object');
 
 };
 
 Zooby = model.register('Zooby', Zooby);
 
 module.exports.Zooby = Zooby;
-

--- a/test/unit/query/query.js
+++ b/test/unit/query/query.js
@@ -5,6 +5,7 @@ var utils = require('utilities')
   , operation = require('../../../lib/query/operation')
   , comparison = require('../../../lib/query/comparison')
   , Zooby = require('../../fixtures/zooby').Zooby
+  , Wooby = require('../../fixtures/wooby').Wooby
   , tests;
 
 var tests = {
@@ -110,8 +111,10 @@ var tests = {
     assert.ok(!query.conditions.operands[0].opts.nocase);
     assert.ok(query.conditions.operands[1].opts.nocase);
   }
-
-
+, 'test object\'s properties with Model': function () {
+    var query = new Query(Zooby, { 'wooby.foo': { like: 'foo' } });
+    assert.ok(query.conditions.isValid());
+  }
 };
 
 module.exports = tests;


### PR DESCRIPTION
— added ability to exclude testing different DB engines if you won't;
— fixed `modelName` retrieval from complex field like `obj.property`;
— automatically transforms `modelName` to `ModelName` in query;
— wrote tests for this case;
