### PR TITLE
don't use model[relation].save sync in testhelper

### DIFF
--- a/test/integration/adapters/helpers.js
+++ b/test/integration/adapters/helpers.js
@@ -21,8 +21,10 @@ module.exports = {
               , description: descrLetters.pop()
               }));
             });
-            model[relation].save(items);
-            doIt();
+            model[relation].save(items, function (err, data) {
+              if (err) { throw err; }
+              doIt();
+            });
           }
           else {
             cb();


### PR DESCRIPTION
avoid errors in setup for async operations with data stores:

catched this one by using the async versions of the levelup api for the leveldb adapter i am currently writing
