### PR TITLE
autoIncrementId fix v2

### DIFF
--- a/lib/adapters/sql/mysql.js
+++ b/lib/adapters/sql/mysql.js
@@ -167,7 +167,7 @@ utils.mixin(Adapter.prototype, new (function () {
       , sql = '';
 
    items.forEach(function (item) {
-      var statement = self._createInsertStatement(item, props);
+      var statement = self._createInsertStatement(item, props, model.autoIncrementId);
       sql += statement;
     });
 
@@ -182,6 +182,10 @@ utils.mixin(Adapter.prototype, new (function () {
           item._saved = true;
         }
         if (data instanceof model.ModelBase) {
+          if (model.autoIncrementId)
+          {
+            data.id = res.insertId;
+          }
           callback(null, data);
         }
         else {


### PR DESCRIPTION
Fixed autoIncrementId problem in the MySQL Adapter.
In case of non autoIncrementId turned on, it still use the UUID.
