### PR TITLE
allow model.defineProperties to be called with an object and allow the p...

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -919,8 +919,23 @@ model.ModelDefinitionBase = function (name) {
   };
 
   this.defineProperties = function (obj) {
-    for (var property in obj) {
-      this.property(property, obj[property].type, obj[property]);
+    var type
+      , options
+      , property;
+
+    for (var name in obj) {
+      property = obj[name];
+
+      if (typeof property === 'string') {
+        type = property;
+        options = {};
+      }
+      else {
+        type = property.type;
+        options = property;
+      }
+
+      this.property(name, type, options);
     }
   }
 


### PR DESCRIPTION
allow model.defineProperties to be called with an object and allow the property to have a string for the type instead of an object.

Example:
this.defineProperties({
    dashboard_id: 'string',
    user_id: 'int',
    title: 'string',
    columns: 'int',
    created_time: 'int'
  });
