### PR TITLE
Allow use of autoincrementing id fields for Postgres and MySQL

### DIFF
--- a/lib/adapters/sql/mysql.js
+++ b/lib/adapters/sql/mysql.js
@@ -15,6 +15,7 @@ _baseConfig = {
 , user: process.env.USER
 , password: null
 , database: process.env.USER
+, autoincrement: false
 };
 
 Adapter = function (options) {
@@ -164,10 +165,11 @@ utils.mixin(Adapter.prototype, new (function () {
       , ctor = model[modelName]
       , reg = model.descriptionRegistry
       , props = reg[modelName].properties
-      , sql = '';
+      , sql = ''
+      , autoincrement = this.config.autoincrement;
 
    items.forEach(function (item) {
-      var statement = self._createInsertStatement(item, props);
+      var statement = self._createInsertStatement(item, props, autoincrement);
       sql += statement;
     });
 

--- a/lib/adapters/sql/postgres.js
+++ b/lib/adapters/sql/postgres.js
@@ -16,6 +16,7 @@ _baseConfig = {
 , password: null
 , host: null
 , port: 5432
+, autoincrement: false
 };
 
 Adapter = function (options) {
@@ -163,10 +164,11 @@ utils.mixin(Adapter.prototype, new (function () {
       , ctor = model[modelName]
       , reg = model.descriptionRegistry
       , props = reg[modelName].properties
-      , sql = '';
+      , sql = ''
+      , autoincrement = this.config.autoincrement;
 
    items.forEach(function (item) {
-      var statement = self._createInsertStatement(item, props);
+      var statement = self._createInsertStatement(item, props, autoincrement);
       statement = statement.replace(/;$/, ' RETURNING id;');
       sql += statement;
     });


### PR DESCRIPTION
Provide an option for Postgres and MySQL configurations to use autoincrementing (numeric) row IDs rather than UUIDs.

Configurable (defaults off) via the database adapter configuration object (e.g. `geddy.config.db`). Set `autoincrement = true` to activate. Configuration affects all tables of the adapter in question.

Not taking in account table creation yet. Will support if needed.
