### PR TITLE
Laxer validation for properties and beforeValidate() as filter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -908,7 +908,7 @@ utils.mixin(model, new (function () {
       , val;
 
     if (typeof item.beforeValidate === 'function') {
-      item.beforeValidate();
+      item.beforeValidate(passedParams);
     }
     item.emit('beforeValidate')
     model[name].emit('beforeValidate', item, passedParams);
@@ -1020,6 +1020,18 @@ utils.mixin(model, new (function () {
       // 'false' changed to false, '8.0' changed to 8, '2112' changed to
       // 2112, etc.
       val = result.val;
+    }
+
+    // If property has been explicitly declared as "not required",
+    // do NOT run validation tests against the property. This allows
+    // developers to define validation rules for cases when the property
+    // IS set, but at the same time allows the property to be left unset or NULL.
+    if( ( ( typeof val === 'undefined' ) || ( val === null ) ) && ( prop.options.required === false ) )
+    {
+      return {
+        err: null,
+        val: val
+      };
     }
 
     // Now go through all the base validations for this property

--- a/lib/index.js
+++ b/lib/index.js
@@ -1022,11 +1022,9 @@ utils.mixin(model, new (function () {
       val = result.val;
     }
 
-    // If property has been explicitly declared as "not required",
-    // do NOT run validation tests against the property. This allows
-    // developers to define validation rules for cases when the property
-    // IS set, but at the same time allows the property to be left unset or NULL.
-    if( ( ( typeof val === 'undefined' ) || ( val === null ) ) && ( prop.options.required === false ) )
+    // Check if property allows nulls or empty values and do not run
+    // validation routines if that's the casse.
+    if( ( ( typeof val === 'undefined' ) && ( prop.options.allowEmpty === true ) ) || ( ( val === null ) && ( prop.options.allowNull === true ) ) )
     {
       return {
         err: null,
@@ -1280,7 +1278,7 @@ model.PropertyDescription = function (name, datatype, o) {
 
   // Creates results similar to `this.validates`, above in ModelDefinitionBase
   // Would be great to remove the duplication of logic
-  for (var p in opts) {
+  //for (var p in opts) { // this for loop is entirely unnecessary, isn't it? -AA
     if (opts.required || opts.length) {
       validations.present =
           new model.ValidationDescription('present', null, validationOpts);
@@ -1304,7 +1302,10 @@ model.PropertyDescription = function (name, datatype, o) {
           new model.ValidationDescription('length', opts.format,
               validationOpts);
     }
-  }
+    if((opts.required || opts.length) && (opts.allowEmpty || opts.allowNull)) {
+       throw new Error( 'Model cannot set a property to be required or have a minimum length while allowing empty or null values' );
+    }
+  //} end of for
   this.validations = validations;
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -996,6 +996,17 @@ utils.mixin(model, new (function () {
       , scenario = opts.scenario
       , locale = options.locale || utils.i18n.getDefaultLocale();
 
+
+    // Check if property allows nulls or empty values and do not run
+    // validation routines if that's the casse.
+    if( ( ( typeof val === 'undefined' ) && ( prop.options.allowEmpty === true ) ) || ( ( val === null ) && ( prop.options.allowNull === true ) ) )
+    {
+      return {
+        err: null,
+        val: val
+      };
+    }
+
     // Validate for the base datatype only if there actually is a value --
     // e.g., undefined will fail the validation for Number, even if the
     // field is optional
@@ -1020,16 +1031,6 @@ utils.mixin(model, new (function () {
       // 'false' changed to false, '8.0' changed to 8, '2112' changed to
       // 2112, etc.
       val = result.val;
-    }
-
-    // Check if property allows nulls or empty values and do not run
-    // validation routines if that's the casse.
-    if( ( ( typeof val === 'undefined' ) && ( prop.options.allowEmpty === true ) ) || ( ( val === null ) && ( prop.options.allowNull === true ) ) )
-    {
-      return {
-        err: null,
-        val: val
-      };
     }
 
     // Now go through all the base validations for this property


### PR DESCRIPTION
Assuming...

```
User = function() {

  this.property( 'username', 'string', { required: true } );
  this.property( 'password', 'string', { required: false } );

  this.validatesFormat( 'username', /^[^a-z]$/ );
  this.validatesFormat( 'password', /^[^a-z]$/ );
};
```

And:

```
var u = new User();

u.setProperties( { username: 'testuser' } );
u.save();
```

...Current validation system will fail, because undefined property `password` will not validate against the regular expression validator I have created. However, typical database design allows default values for fields not mentioned in the insert query, not to mention use of `null`.

Laxer validation checks if the property's `required` parameter has been explicitly been set to `false`. If that is the case, the validation test will not be run against the empty value, because we're signalling that empty/null is safe.

---

Secondly, properties are passed to `beforeValidate()` callback as its first parameter. This is to allow `beforeValidate()` function to be used as a filter:

```
User.prototype.beforeValidate = function( params )
{
  if( params.hasOwnProperty( 'username' ) === true )
  {
    params.username = params.username.toLowerCase();
  }
};

var u = new User();

u.setProperties( { username: 'TESTuser' } );
u.save();
```

Currently, validation would fail, because User has a validation tester which allows only lowercase letters through. In many cases -- particularly with data received from users -- we could safely enforce data formatting rules so that we won't have to worry about the format of the data we received.
