### PR TITLE
added ability to specify tableName on a model by model bases. Only works...

### DIFF
--- a/lib/adapters/sql/converter.js
+++ b/lib/adapters/sql/converter.js
@@ -4,13 +4,26 @@ var utils = require('utilities')
 module.exports = new (function () {
   this.COLUMN_NAME_DELIMITER = '"';
 
+  /**
+   * Get the TableName of the Model. First checks if it
+   * was defined on the model, otherwise it performs a pluralization of
+   * the model name
+   *
+   * @param {string} name - the name of the model
+   * @returns {model.ModelDescription.tableName|string}
+   * @private
+   */
   this._tableizeModelName = function (name) {
-    return utils.string.getInflection(name, 'filename', 'plural');
+    // Get the Correct model name (in case the name is passed in with the wrong case)
+    var modelName = utils.string.getInflection(name, 'constructor', 'singular');
+
+    return (model.descriptionRegistry[modelName] && model.descriptionRegistry[modelName].tableName)
+      || utils.string.getInflection(name, 'filename', 'plural');
   };
 
   this._modelizeTableName = function (name, ownerName) {
     var modelName
-      , ownerModelName
+      , ownerModelName;
     modelName = utils.string.getInflection(name, 'constructor', 'singular');
     if (ownerName && name != ownerName) {
       ownerModelName = utils.string.getInflection(ownerName, 'constructor', 'singular');

--- a/lib/index.js
+++ b/lib/index.js
@@ -596,6 +596,9 @@ utils.mixin(model, new (function () {
     ModelDefinition.prototype = new model.ModelDefinitionBase(name);
     defined = new ModelDefinition();
 
+    // Set the table name from the instance or model definition
+    model.descriptionRegistry[name].tableName = defined.tableName || (ModelDefinition.tableName || null);
+
     // Create the constructor function to use when calling static
     // ModelCtor.create. Gives them the proper instanceof value,
     // and .valid, etc. instance-methods.
@@ -907,6 +910,7 @@ model.ModelDefinitionBase = function (name) {
       };
 
   this.name = name;
+  this.tableName = null;
 
   this.setAdapter = function (name, config) {
     var adapter = adapters.create(name, config);
@@ -1055,6 +1059,7 @@ model.ModelDescription = function (name) {
   this.name = name;
   this.properties = {};
   this.associations = {};
+  this.tableName = null;
 };
 
 model.PropertyDescription = function (name, datatype, o) {


### PR DESCRIPTION
... with SQL adapters at the moment. I only added it to SQL adapters at the moment because SQL was the only one that had a single place to check for table name. Also you can change the table name on a model instance or a model definition.  I added it to the model definition so that it can be set on a framework level by setting the models table names when you load the models into your framework.
