### PR TITLE
Error message better when trying to use an invalid model prop.

### DIFF
--- a/lib/query/query.js
+++ b/lib/query/query.js
@@ -204,6 +204,11 @@ Query.prototype = new (function () {
         props = model.descriptionRegistry[modelName].properties;
         descr = props[keyName];
 
+        if (typeof descr === 'undefined') {
+          throw new Error('The property "' + keyName + '" is not a valid ' +
+                          'property on the ' + modelName + ' model.');
+        }
+
           // {id: ['foo', 'bar', 'baz']}, shorthand for Inclusion
         if (Array.isArray(val)) {
           type = 'in';


### PR DESCRIPTION
When using an invalid property while querying the model, like so:

``` javascript
geddy.model.MyModel.find({ bad_prop: 'some_value' }, function () {
// ...
});
```

Geddy model would throw this exception:

```
TypeError: Cannot read property 'datatype' of undefined at _createComparison
(/usr/local/lib/node_modules/geddy/node_modules/model/lib/query/query.js:232:27) at _createOperation
(/usr/local/lib/node_modules/geddy/node_modules/model/lib/query/query.js:175:43) at Query.initialize
(/usr/local/lib/node_modules/geddy/node_modules/model/lib/query/query.js:345:40) at Query
(/usr/local/lib/node_modules/geddy/node_modules/model/lib/query/query.js:12:19) at Function.obj.all
(/usr/local/lib/node_modules/geddy/node_modules/model/lib/index.js:378:15) at show
(/Users/my_username/src/my_app/app/controllers/my_controller.js:12:26) at callback
(/usr/local/lib/node_modules/geddy/lib/controller/base_controller.js:282:22) at controller.BaseController._handleAction
(/usr/local/lib/node_modules/geddy/lib/controller/base_controller.js:295:7) at cb [as callback]
(/usr/local/lib/node_modules/geddy/lib/app/index.js:258:36) at async.Initializer.complete
(/usr/local/lib/node_modules/geddy/node_modules/utilities/lib/async.js:286:10)
```

This is pretty unhelpful – I have changed the error to be more informative to the end-user:

```
Error: The property "bad_prop" is not a valid property on the MyModel model. at _createComparison
```
