### PR TITLE
Adding a better error message when a validation name is invalid.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -983,6 +983,12 @@ model.ModelDefinitionBase = function (name) {
     // Default to 'create' and 'update' only for scenarios
     opts.on = opts.on || ['create', 'update'];
 
+    if (typeof reg[this.name].properties[name] === 'undefined') {
+      throw new Error('Validation cannot be added for "' + name +
+                      '": property does not exist on the ' + this.name +
+                      ' model.');
+    }
+
     reg[this.name].properties[name].validations[condition] =
         new model.ValidationDescription(condition, reference, opts);
   };

--- a/test/unit/invalid_models.js
+++ b/test/unit/invalid_models.js
@@ -1,0 +1,66 @@
+var assert = require('assert')
+  , model = require('../../lib')
+  , tests;
+
+
+function assertValidationErrorIsThrown (InvalidModel) {
+  assert.throws(
+    function () {
+      model.register('InvalidModel', InvalidModel);
+    },
+    /Validation\scannot\sbe\sadded/
+  );
+}
+
+
+tests = {
+  "test instantiating a model with validatesPresent on a property that doesn't exist": function () {
+    var InvalidModel = function () {
+      this.validatesPresent('monkies');
+    };
+
+    assertValidationErrorIsThrown(InvalidModel);
+  }
+
+, "test instantiating a model with validatesConfirmed on a property that doesn't exist": function () {
+    var InvalidModel = function () {
+      this.validatesConfirmed('monkies', 'realMonkies');
+    };
+
+    assertValidationErrorIsThrown(InvalidModel);
+  }
+
+, "test instantiating a model with validatesAbsent on a property that doesn't exist": function () {
+    var InvalidModel = function () {
+      this.validatesAbsent('bananas');
+    };
+
+    assertValidationErrorIsThrown(InvalidModel);
+  }
+
+, "test instantiating a model with validatesLength on a property that doesn't exist": function () {
+    var InvalidModel = function () {
+      this.validatesLength('gorillas', {is: 12});
+    };
+
+    assertValidationErrorIsThrown(InvalidModel);
+  }
+
+, "test instantiating a model with validatesFormat on a property that doesn't exist": function () {
+    var InvalidModel = function () {
+      this.validatesFormat('chimpanzees', /hairy/);
+    };
+
+    assertValidationErrorIsThrown(InvalidModel);
+  }
+
+, "test instantiating a model with validatesWithFunction on a property that doesn't exist": function () {
+    var InvalidModel = function () {
+      this.validatesWithFunction('ocelot', function () {});
+    };
+
+    assertValidationErrorIsThrown(InvalidModel);
+  }
+};
+
+module.exports = tests;


### PR DESCRIPTION
When you tried to add a validator on a property that was non-existent, like this:

```
var MyModel = function () {
  this.validatesPresent('bad_prop');
};
```

Gedddy Model would throw this error:

```
/usr/local/lib/node_modules/geddy/node_modules/model/lib/index.js:955
    reg[this.name].properties[name].validations[condition] =
                                   ^
TypeError: Cannot read property 'validations' of undefined
```

Which is not terribly helpful. When you add a validation for a non-existent property now, it will throw this error:

```
Error: Validation cannot be added for "bad_prop": property does
not exist on the MyModel model.
```
