### PR TITLE
Adding a clearer error message when trying to use an invalid includes.

### DIFF
--- a/lib/adapters/sql/base.js
+++ b/lib/adapters/sql/base.js
@@ -162,7 +162,8 @@ utils.mixin(Adapter.prototype, new (function () {
       , assumedTableName
       , props
       , propArr
-      , propName;
+      , propName
+      , association;
 
     // Assumed name is a real model
     if (model.descriptionRegistry[assumedName]) {
@@ -172,7 +173,14 @@ utils.mixin(Adapter.prototype, new (function () {
     // actual model via it's owner's associations list
     else {
       ownerName = utils.string.getInflection(ownerModelName, 'constructor', 'singular');
-      name = model.getAssociation(ownerName, assumedName).model;
+      association = model.getAssociation(ownerName, assumedName);
+
+      if (typeof association === 'undefined') {
+        throw new Error('Could not find the associated model "' + assumedName +
+                        '" on the "' + ownerName + '" model.');
+      }
+
+      name = association.model;
     }
 
     tableName = this._tableizeModelName(name);

--- a/test/integration/adapters/sql/eager_assn.js
+++ b/test/integration/adapters/sql/eager_assn.js
@@ -146,6 +146,17 @@ tests = {
     });
   }
 
+, 'test includes, using an invalid association name throws the proper error': function () {
+    assert.throws(
+      function () {
+        model.Person.all({}, { includes: 'this_doesnt_exist' }, function (err, data) {
+
+        });
+      },
+      /Could\snot\sfind\sthe\sassociated\smodel/
+    );
+  }
+
 , 'test named, reflexive, hasMany/through with properties on the join-model': function (next) {
     model.Person.all({}, {sort: 'title'}, function (err, data) {
       if (err) { throw err; }


### PR DESCRIPTION
Before the error was this:

```
TypeError: Cannot read property 'model' of undefined at utils.mixin._createSelectStatement
```

Now it is this:

```
Error: Could not find the associated model "BadAssociation" on the "GoodModel" model. at utils.mixin._createSelectStatement
```

Test added as well.
