### PR TITLE
fix crash on SQL datastores when using defaultAdapter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -636,6 +636,10 @@ utils.mixin(model, new (function () {
     // Preserve any inherited shit from the definition proto
     utils.enhance(ModelCtor.prototype, origProto);
 
+    // Set the model adapter to the defaultadapter in case there is none
+    if (!ModelCtor.adapter)
+      ModelCtor.adapter = this.defaultAdapter
+    
     model[name] = ModelCtor;
 
     return ModelCtor;


### PR DESCRIPTION
this:

```
var model = require('model');
// this causes a crash
model.defaultAdapter = model.createAdapter('sqlite', { database: './dev.db' }); 
// this doesnt
//model.defaultAdapter = model.createAdapter('memory', { database: './dev.db' }); 

function Test() {
    this.defineProperties({
        "foobar": { "type" : "int "}
    });
}

Test = model.register('Test',Test);
Test.first(1,function(err,first) {
    console.log(err);
    console.log(first);
})
```

Crashes in adapters\sql\base.js:368 due to query.model.adapter being undefined as setAdapter has not been called because we're using a defaultAdapter. 

I'm guessing this happens across all SQL adapters, but only tested with SQLite and MySQL (very quickly).

This PR makes sure the adapter is set on a model even when using defaultAdapter.
