### PR TITLE
Display "clean" models and allow for extra (non-schema-defined) properties

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -971,7 +971,7 @@ model.ModelDefinitionBase = function (name) {
     this.adapter = adapter;
   };
 
-  this.allowExtra = function (/*allow*/) {
+  this.allowExtra = function (/* allow */) {
 
     // For semantic clarity, empty invocation "allows" the extra field.
     // Takes the optional boolean to disallow extra


### PR DESCRIPTION
I needed a LevelDB ODM that would allow me to define a very basic document schema, but then allow for ad hoc expansion of that on a document-by-document basis. Think of it like this, every doc of a type "Page" would require a title and a path, but any doc could then have N more fields of any name added on the fly.

Many ODM/ORMs have this capability, so I added it to Model in what seemed to be the least invasive way possible. 

I put together all the model instance methods and define them as non-enumerable. I then have an optional per-model method "allowExtra()" that takes a boolean and will set the handling mode when unknown fields are seen during model creation. Because all internal methods / props have been hidden, we can safely assume all enumerable properties are fair game for storage.

The side benefit is having much cleaner looking models when you log them.

For example:

```
// Page schema like { title: { type: 'string', required: true }, path: { type: 'string', required: true } }
var page = Page.create({ title: 'Hello', path: '/hello', foo: 'bar' });
// --> { title: 'Hello', path: '/hello' }
...
var Page = function () { 
  this.allowExtra(true);
  ...
};
var page = Page.create({ title: 'Hello', path: '/hello', foo: 'bar' });
// --> { title: 'Hello', path: '/hello', foo: 'bar' }
```
