### PR TITLE
Adding Level adapter support for Sublevel and Multilevel

### DIFF
--- a/lib/adapters/level/index.js
+++ b/lib/adapters/level/index.js
@@ -1,5 +1,4 @@
 var model = require('../../index')
-  , path = require('path')
   , utils = require('utilities')
   , level
   , multilevel
@@ -38,6 +37,7 @@ if (!level && !multilevel) {
 _baseConfig = {
   db: '/data/level',
   sublevel: '',
+  keyPrefix: true,
   multilevel: {
     port: 3000,
     host: 'localhost',
@@ -64,7 +64,19 @@ Adapter.prototype.constructor = Adapter;
 utils.mixin(Adapter.prototype, new (function () {
 
   this._initLevel = function (config) {
-    this.db = level(config.db, {keyEncoding: 'utf8', valueEncoding: 'json'});
+    var db
+      , sublevel;
+
+    db = level(config.db, {keyEncoding: 'utf8', valueEncoding: 'json'});
+
+    if (config.sublevel) {
+      // Load sublevel, and set db
+      sublevel = utils.file.requireLocal('level-sublevel');
+      db = sublevel(db);
+      db = db.sublevel(config.sublevel);
+    }
+
+    this.db = db;
   };
 
   this._initMultilevel = function (config) {
@@ -73,7 +85,7 @@ utils.mixin(Adapter.prototype, new (function () {
       , manifest;
 
     if (config.multilevel.manifest) {
-      manifest = require(path.join(process.cwd(), config.multilevel.manifest));
+      manifest = require(config.multilevel.manifest);
     }
 
     db = multilevel.client(manifest);
@@ -97,6 +109,21 @@ utils.mixin(Adapter.prototype, new (function () {
     }
   };
 
+  this._generateKey = function (type, id) {
+    var keyPrefix = this.config.keyPrefix;
+
+    if (keyPrefix === true) {
+      return type + delimiter + id;
+
+    }
+    else if (keyPrefix === false) {
+      return id;
+    }
+    else {
+      return keyPrefix + delimiter + id;
+    }
+  }
+
   this.init = function () {
     var config = this.config;
 
@@ -108,8 +135,9 @@ utils.mixin(Adapter.prototype, new (function () {
   };
 
   this.load = function (query, callback) {
-    var key = query.model.modelName
-      , props = model.descriptionRegistry[key].properties
+    var type = query.model.modelName
+      , key
+      , props = model.descriptionRegistry[type].properties
       , datatype
       , id = query.byId
       , conditions
@@ -121,10 +149,13 @@ utils.mixin(Adapter.prototype, new (function () {
       , val
       , filter
       , res = []
-      , db = this.db;
+      , db = this.db
+      , startKey
+      , endKey;
 
     if (id) {
-      db.get(key + delimiter + id, function (err, item) {
+      key = this._generateKey(type, id);
+      db.get(key, function (err, item) {
         if (err && err.notFound) {
           // handle a 'NotFoundError' here
           if(limit == 1)
@@ -154,7 +185,10 @@ utils.mixin(Adapter.prototype, new (function () {
 
       filter = new Function('data', 'return (' + conditions + ')');
 
-      db.createReadStream({start: key + delimiter, end: key + delimiter + '\xFF'})
+      startKey = this._generateKey(type, '');
+      endKey = this._generateKey(type, '\xFF');
+
+      db.createReadStream({start: startKey, end: endKey})
         .on('data', function (item) {
           data = item.value;
 
@@ -195,7 +229,8 @@ utils.mixin(Adapter.prototype, new (function () {
   };
 
   this.update = function (data, query, callback) {
-    var key = query.model.modelName
+    var type = query.model.modelName
+      , key
       , id = query.byId
       , ids
       , item = data
@@ -203,7 +238,8 @@ utils.mixin(Adapter.prototype, new (function () {
 
     if (id) {
       item = item.toJSON();
-      db.put(key + delimiter + id, item, function (err) {
+      key = this._generateKey(type, id);
+      db.put(key, item, function (err) {
         if (err) {
           callback(err, null);
         }
@@ -223,14 +259,17 @@ utils.mixin(Adapter.prototype, new (function () {
   };
 
   this.remove = function (query, callback) {
-    var key = query.model.modelName
+    var type = query.model.modelName
+      , self = this
+      , key
       , id = query.byId
       , db = this.db
       , ids
       , remove;
 
     if (id) {
-      db.del(key + delimiter + id, function (err) {
+      key = this._generateKey(type, id);
+      db.del(key, function (err) {
         if (err) {
           callback(err, null);
         }
@@ -244,7 +283,8 @@ utils.mixin(Adapter.prototype, new (function () {
       remove = function () {
         var id;
         if ((id = ids.shift())) {
-          db.del(key + delimiter + id, function (err) {
+          key = self._generateKey(type, id);
+          db.del(key, function (err) {
             if (err) {
               callback(err, null);
             }
@@ -283,7 +323,8 @@ utils.mixin(Adapter.prototype, new (function () {
 
   this.insert = function (data, opts, callback) {
     var items = Array.isArray(data) ? data.slice() : [data]
-      , key = items[0].type
+      , self = this
+      , type = items[0].type
       , db = this.db
       , id
       , insert;
@@ -297,7 +338,8 @@ utils.mixin(Adapter.prototype, new (function () {
         item.id = id;
         item = item.toJSON();
 
-        db.put(key + delimiter + id, item, function (err) {
+        key = self._generateKey(type, id);
+        db.put(key, item, function (err) {
           if (err) {
             return callback(err, null);
           }
@@ -325,16 +367,22 @@ utils.mixin(Adapter.prototype, new (function () {
   };
 
   this.dropTable = function (names, callback) {
-    var keys = Array.isArray(names) ? names.slice() : [names]
-      , db = this.db;
+    var types = Array.isArray(names) ? names.slice() : [names]
+      , db = this.db
+      , startKey
+      , endKey
+      , self = this;
 
     var drop = function () {
-      var key
+      var type
         , tableName;
-      if ((key = keys.shift())) {
+      if ((type = types.shift())) {
         // tableName = utils.inflection.pluralize(c);
         // tableName = utils.string.snakeize(tableName);
-        db.createReadStream({start: key + delimiter, end: key + delimiter + '\xFF'})
+        startKey = self._generateKey(type, '');
+        endKey = self._generateKey(type, '\xFF');
+
+        db.createReadStream({start: startKey, end: endKey})
           .pipe(db.createWriteStream({ type: 'del' }))
           .on('close', function () {
             drop();


### PR DESCRIPTION
I needed support for both these for a current project. Fairly straightforward implementation using `Net.connect()`.

Summary of changes:
- Update local module requires to support `LevelUp` and `Multilevel` as well as `Level`
- Update adapter init to branch logic for Multilevel vs. plain Level
- Update config to support a sublevel name, and handle in init (will attempt a local require for level-sublevel, and throw an error if it doesn't exist).
- Update config to disable / modify `keyPrefix` (to avoid duplicate prefixes when using sublevels)
- Add connect/disconnect methods which I really uncertain of. Docs indicate they are just for getting connection feedback, but the mongo adapter seems to use them for acquiring the db connection itself. I followed the docs.
