### PR TITLE
Fix failing require with webpack

### DIFF
--- a/lib/adapters/index.js
+++ b/lib/adapters/index.js
@@ -76,15 +76,13 @@ adapters = new (function () {
 
   this.create = function (name, config) {
     var info = this.getAdapterInfo(name)
-      , ctorPath
       , ctor;
 
     if (!info) {
       throw new Error('"' + name + '" is not a valid adapter.');
     }
 
-    ctorPath = path.join(__dirname, info.path)
-    ctor = require(ctorPath).Adapter;
+    ctor = require('./' + info.path).Adapter;
 
     return new ctor(config || {});
   };


### PR DESCRIPTION
I am using `model` in an isomorphic app, and this `path.join(__dirname, info.path)` fails because [webpack](https://github.com/webpack/webpack) transform `__dirname` into `/`. 
So the failing result is `ctor = require('/memory/index').Adapter;` (notice the absolute path).
