### PR TITLE
Add clearer error message when a model can't be found

### DIFF
--- a/lib/association/index.js
+++ b/lib/association/index.js
@@ -248,6 +248,12 @@ association = new (function () {
         // Create join-instance
         params = {};
         params[selfKeyName] = this.id;
+
+        if (!model[through]) {
+          throw new Error('The ' + through + ' model could not be found. ' +
+              'Have you required it?');
+        }
+
         joinInstance = model[through].create(params);
 
         unsaved = this._unsavedAssociations || [];


### PR DESCRIPTION
Re: #240

First the error message I was getting was just "Cannot call method 'create' of undefined" trying to use "FamiliesUsers". This took me a awhile to figure out it was actually coming from inside of `model`'s code, not mine. Then I wrongly assumed that `model` lazily loaded models by their file name.

`model` is nice because it's sort of magic in that it handles a ton of stuff for you like associations, pluralization and such so sometimes it's hard to know where the magic ends and when you need to be explicit. This error message should help by:
1. Making it much more clear this is a custom error message, therefore not in your code, `model`'s and
2. reminding you to require the file if you forgot it or didn't know you needed to manually do it.
